### PR TITLE
feat: NanumSquare Neo 폰트 적용, 글로벌 스타일 수정

### DIFF
--- a/cypress/e2e/sample.cy.ts
+++ b/cypress/e2e/sample.cy.ts
@@ -1,8 +1,0 @@
-describe("cypress 테스트", () => {
-    it("test", () => {
-        cy.visit("/");
-        cy.get("button#increment").should("have.text", "count is 0");
-        cy.get("button#increment").click();
-        cy.get("button#increment").should("have.text", "count is 1");
-    });
-});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,15 @@
 import { BrowserRouter } from "react-router-dom";
 
+import { FontsStyle } from "@/styles/fonts";
+import { GlobalStyle } from "@/styles/global";
+
 import { Router } from "./Router";
-import { GlobalStyle } from "./styles/global";
 import { Global } from "@emotion/react";
 
 export default function App() {
     return (
         <BrowserRouter>
-            <Global styles={GlobalStyle} />
+            <Global styles={[FontsStyle, GlobalStyle]} />
             <Router />
         </BrowserRouter>
     );

--- a/src/components/typography/Text.tsx
+++ b/src/components/typography/Text.tsx
@@ -7,6 +7,10 @@ export interface TextProps extends React.ComponentProps<"span"> {
     children: React.ReactNode;
 }
 
-export const Text = forwardRef<HTMLSpanElement, TextProps>(({ children, ...props }) => {
-    return <TextElement {...props}>{children}</TextElement>;
+export const Text = forwardRef<HTMLSpanElement, TextProps>(({ children, ...props }, ref) => {
+    return (
+        <TextElement ref={ref} {...props}>
+            {children}
+        </TextElement>
+    );
 });

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,68 @@
+import { css } from "@emotion/react";
+
+export const FontsStyle = css`
+    @font-face {
+        font-family: "NanumSquareNeo";
+        font-weight: 300;
+        src: url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-aLt.eot);
+        src:
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-aLt.eot?#iefix)
+                format("embedded-opentype"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-aLt.woff)
+                format("woff"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-aLt.ttf)
+                format("truetype");
+    }
+
+    @font-face {
+        font-family: "NanumSquareNeo";
+        font-weight: 400;
+        src: url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-bRg.eot);
+        src:
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-bRg.eot?#iefix)
+                format("embedded-opentype"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-bRg.woff)
+                format("woff"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-bRg.ttf)
+                format("truetype");
+    }
+
+    @font-face {
+        font-family: "NanumSquareNeo";
+        font-weight: 700;
+        src: url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-cBd.eot);
+        src:
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-cBd.eot?#iefix)
+                format("embedded-opentype"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-cBd.woff)
+                format("woff"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-cBd.ttf)
+                format("truetype");
+    }
+
+    @font-face {
+        font-family: "NanumSquareNeo";
+        font-weight: 800;
+        src: url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-dEb.eot);
+        src:
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-dEb.eot?#iefix)
+                format("embedded-opentype"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-dEb.woff)
+                format("woff"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-dEb.ttf)
+                format("truetype");
+    }
+
+    @font-face {
+        font-family: "NanumSquareNeo";
+        font-weight: 900;
+        src: url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-eHv.eot);
+        src:
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-eHv.eot?#iefix)
+                format("embedded-opentype"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-eHv.woff)
+                format("woff"),
+            url(https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-eHv.ttf)
+                format("truetype");
+    }
+`;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -5,6 +5,13 @@ export const GlobalStyle = css`
     padding: 0;
     border: 0;
 
+    body {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        font-family: "NanumSquareNeo", sans-serif;
+    }
+
     box-sizing: border-box;
 
     img {

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,9 +1,12 @@
 import { css } from "@emotion/react";
 
 export const GlobalStyle = css`
-    margin: 0;
-    padding: 0;
-    border: 0;
+    * {
+        margin: 0;
+        padding: 0;
+        border: 0;
+        box-sizing: border-box;
+    }
 
     body {
         margin: 0;
@@ -11,8 +14,6 @@ export const GlobalStyle = css`
         border: 0;
         font-family: "NanumSquareNeo", sans-serif;
     }
-
-    box-sizing: border-box;
 
     img {
         display: block;


### PR DESCRIPTION
## 구현한 기능

- Global Style에 [NanumSquare Neo](https://noonnu.cc/font_page/1053) 폰트 추가
- `font-weight` 300(Light), 400(Regular), 700(Bold), 800(ExtraBold), 900(Heavy) 각각에 대해 폰트 파일 매핑
- `body` 태그에 user agent stylesheet 에 의해 기본으로 들어가 있는 margin 제거

## 논의하고 싶은 내용

-

## 기타

- Variable Font로 깔끔하게 적용하려고 했으나 왜인지 윈도우 환경에서 제대로 표시되지 않아서 그냥 기존 방식으로 적용했습니다.
