### PR TITLE
feat: 라우트 페이지간 전환 애니메이션 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,12 @@
                 "@emotion/react": "^11.13.3",
                 "@emotion/styled": "^11.13.0",
                 "hangul-js": "^0.2.6",
-                "primereact": "^10.8.2",
                 "html2canvas": "^1.4.1",
+                "primereact": "^10.8.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^6.26.1",
+                "react-transition-group": "^4.4.5",
                 "zustand": "^4.5.5"
             },
             "devDependencies": {
@@ -4531,14 +4532,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/css-line-break": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-            "dependencies": {
-                "utrie": "^1.0.2"
             }
         },
         "node_modules/css-line-break": {
@@ -10827,14 +10820,6 @@
                 "utrie": "^1.0.2"
             }
         },
-        "node_modules/text-segmentation": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-            "dependencies": {
-                "utrie": "^1.0.2"
-            }
-        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -11215,14 +11200,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/utrie": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-            "dependencies": {
-                "base64-arraybuffer": "^1.0.2"
             }
         },
         "node_modules/utrie": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "hangul-js": "^0.2.6",
-        "primereact": "^10.8.2",
         "html2canvas": "^1.4.1",
+        "primereact": "^10.8.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.26.1",
+        "react-transition-group": "^4.4.5",
         "zustand": "^4.5.5"
     },
     "devDependencies": {

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,28 +1,32 @@
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
+import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import { RootLayout } from "./components/layout/RootLayout";
+import AnalyticsPage from "./pages/AnalyticsPage";
 import HomePage from "./pages/HomePage";
 import LoadingPage from "./pages/ResultLoading";
 import ResultPage from "./pages/ResultPage";
-
 import ResultShare from "./pages/ResultShare";
 import SelectPage from "./pages/SelectPage";
-
-import AnalyticsPage from "./pages/AnalyticsPage";
-
+import "@/transition/fade-slide.css";
 
 export const Router = () => {
-    return (
-        <Routes>
-            <Route path="/" element={<RootLayout />}>
-                <Route index element={<HomePage />}></Route>
-                <Route path="/loading" element={<LoadingPage />} />
-                <Route path="/result" element={<ResultPage />}></Route>
-                <Route path="/share" element={<ResultShare />}></Route>
-                <Route path="/select" element={<SelectPage />}></Route>
-                <Route path="/analytics" element={<AnalyticsPage />}></Route>
+    const location = useLocation();
 
-            </Route>
-        </Routes>
+    return (
+        <TransitionGroup>
+            <CSSTransition key={location.key} timeout={500} classNames="fade-slide">
+                <Routes location={location}>
+                    <Route path="/" element={<RootLayout />}>
+                        <Route index element={<HomePage />}></Route>
+                        <Route path="/loading" element={<LoadingPage />} />
+                        <Route path="/result" element={<ResultPage />}></Route>
+                        <Route path="/share" element={<ResultShare />}></Route>
+                        <Route path="/select" element={<SelectPage />}></Route>
+                        <Route path="/analytics" element={<AnalyticsPage />}></Route>
+                    </Route>
+                </Routes>
+            </CSSTransition>
+        </TransitionGroup>
     );
 };

--- a/src/transition/fade-slide.css
+++ b/src/transition/fade-slide.css
@@ -1,0 +1,32 @@
+/* 정방향 || 들어오는 효과 */
+.fade-slide-enter {
+    opacity: 0;
+    transform: translateX(20px);
+}
+
+.fade-slide-enter-active {
+    position: absolute;
+    opacity: 1;
+    transform: translateX(0px);
+    transition: all 500ms cubic-bezier(0.27, 0.02, 0.26, 0.99) 100ms;
+}
+
+.fade-slide-enter-done {
+    opacity: 1;
+}
+
+/* 정방향 || 사라지는 효과 */
+.fade-slide-exit {
+    opacity: 1;
+    transform: translateX(0px);
+}
+
+.fade-slide-exit-active {
+    opacity: 0;
+    transform: translateX(-70px);
+    transition: all 400ms cubic-bezier(0.27, 0.02, 0.26, 0.99);
+}
+
+.fade-slide-exit-done {
+    opacity: 0;
+}


### PR DESCRIPTION
## 구현한 기능

- route간 페이지 전환 애니메이션 추가 (fade-in + slide-in)

## 논의하고 싶은 내용

- 선지 선택 페이지는 innerText를 변경하는 방식이라 전환 애니메이션이 적용 안됨

## 기타

- 최신 리액트라서 `Warning: findDom is deprecated` 경고가 발생함. 그래도 작동은 잘 됨
