### PR TITLE
chore: CD를 위한 Github Action 워크플로우 작성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,10 @@ on:
         workflows: ["Run Tests"]
         types:
             - completed
+    workflow_dispatch:
+    pull_request:
+        branches: ["release"]
+        types: ["closed"]
 
 env:
     NODE_VERSION: 20

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,48 @@
+name: Deploy Production
+
+on:
+    workflow_run:
+        workflows: ["Run Tests"]
+        types:
+            - completed
+
+env:
+    NODE_VERSION: 20
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Install NodeJS
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{env.NODE_VERSION}}
+
+            - name: Code Checkout
+              uses: actions/checkout@v4
+
+            - name: Install Dependencies
+              run: npm ci
+
+            - name: Build Production
+              run: npm run build
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
+                  aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+                  aws-region: ap-southeast-2
+
+            - name: Upload to S3
+              env:
+                  BUCKET_NAME: ${{secrets.AWS_S3_BUCKET_NAME}}
+              run: aws s3 sync ./dist s3://$BUCKET_NAME --delete
+
+            - name: CloudFront Invalidation
+              env:
+                  CLOUD_FRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID}}
+              run: |
+                  aws cloudfront create-invalidation \
+                    --distribution-id $CLOUD_FRONT_ID --paths /*


### PR DESCRIPTION
## 구현한 기능

- 배포 자동화를 위해 Github Action 워크플로우 `cd.yml` 작성
	- `ci.yml` 워크플로우가 완료되면 이어서 `cd.yml` 수행되도록 설정
	- 소스 빌드 후 S3 업로드와 CloudFront Cache Invalidate 수행하도록 설정
	- AWS 계정 정보 등을 Repository Secrets에 secret variables 로 등록하여 `cd.yml` 에서 참조하도록 안전하게 구현

## 논의하고 싶은 내용

- 지금 Route53 DNS 정보 확인해보니 서브도메인 `www.dongbti.com`만 CloudFront 배포에 연결되어 있는것 같은데, 루트 도메인(`dongbti.com`) 접속시 `www.dongbti.com` 로 redirect 하도록 하면 어떨까요?

## 기타

-
